### PR TITLE
Date helper datetime support

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,3 @@
+import Config
+
+config :elixir, :time_zone_database, Tz.TimeZoneDatabase

--- a/lib/crontab/date_checker.ex
+++ b/lib/crontab/date_checker.ex
@@ -27,7 +27,7 @@ defmodule Crontab.DateChecker do
       true
 
   """
-  @spec matches_date?(cron_expression :: CronExpression.t(), date :: DateHelper.date()) ::
+  @spec matches_date?(cron_expression :: CronExpression.t(), date :: date) ::
           boolean | no_return
   def matches_date?(cron_expression_or_condition_list, date)
 
@@ -42,7 +42,7 @@ defmodule Crontab.DateChecker do
 
   @spec matches_date?(
           condition_list :: CronExpression.condition_list(),
-          date :: DateHelper.date()
+          date :: date
         ) :: boolean
   def matches_date?([], _), do: true
 
@@ -65,7 +65,7 @@ defmodule Crontab.DateChecker do
   @spec matches_date?(
           interval :: CronExpression.interval(),
           condition_list :: CronExpression.condition_list(),
-          date :: DateHelper.date()
+          date :: date
         ) :: boolean
   def matches_date?(_, [:* | _], _), do: true
   def matches_date?(_, [], _), do: false
@@ -84,7 +84,7 @@ defmodule Crontab.DateChecker do
           interval :: CronExpression.interval(),
           values :: [CronExpression.time_unit()],
           condition :: CronExpression.value(),
-          date :: DateHelper.date()
+          date :: date
         ) :: boolean
   defp matches_specific_date?(_, [], _, _), do: false
   defp matches_specific_date?(_, _, :*, _), do: true
@@ -175,7 +175,7 @@ defmodule Crontab.DateChecker do
     end
   end
 
-  @spec get_interval_value(interval :: CronExpression.interval(), date :: DateHelper.date()) :: [
+  @spec get_interval_value(interval :: CronExpression.interval(), date :: date) :: [
           CronExpression.time_unit()
         ]
   defp get_interval_value(:second, %{second: second}), do: [second]

--- a/lib/crontab/date_checker.ex
+++ b/lib/crontab/date_checker.ex
@@ -7,6 +7,8 @@ defmodule Crontab.DateChecker do
 
   alias Crontab.DateHelper
 
+  @type date :: NaiveDateTime.t() | DateTime.t()
+
   @doc """
   Check a condition list against a given date.
 

--- a/lib/crontab/date_checker.ex
+++ b/lib/crontab/date_checker.ex
@@ -7,8 +7,6 @@ defmodule Crontab.DateChecker do
 
   alias Crontab.DateHelper
 
-  @type date :: NaiveDateTime.t() | DateTime.t()
-
   @doc """
   Check a condition list against a given date.
 
@@ -27,7 +25,8 @@ defmodule Crontab.DateChecker do
       true
 
   """
-  @spec matches_date?(cron_expression :: CronExpression.t(), date :: date) :: boolean | no_return
+  @spec matches_date?(cron_expression :: CronExpression.t(), date :: DateHelper.date()) ::
+          boolean | no_return
   def matches_date?(cron_expression_or_condition_list, date)
 
   def matches_date?(%CronExpression{reboot: true}, _),
@@ -39,7 +38,10 @@ defmodule Crontab.DateChecker do
     |> matches_date?(execution_date)
   end
 
-  @spec matches_date?(condition_list :: CronExpression.condition_list(), date :: date) :: boolean
+  @spec matches_date?(
+          condition_list :: CronExpression.condition_list(),
+          date :: DateHelper.date()
+        ) :: boolean
   def matches_date?([], _), do: true
 
   def matches_date?([{interval, conditions} | tail], execution_date) do
@@ -61,7 +63,7 @@ defmodule Crontab.DateChecker do
   @spec matches_date?(
           interval :: CronExpression.interval(),
           condition_list :: CronExpression.condition_list(),
-          date :: date
+          date :: DateHelper.date()
         ) :: boolean
   def matches_date?(_, [:* | _], _), do: true
   def matches_date?(_, [], _), do: false
@@ -80,7 +82,7 @@ defmodule Crontab.DateChecker do
           interval :: CronExpression.interval(),
           values :: [CronExpression.time_unit()],
           condition :: CronExpression.value(),
-          date :: date
+          date :: DateHelper.date()
         ) :: boolean
   defp matches_specific_date?(_, [], _, _), do: false
   defp matches_specific_date?(_, _, :*, _), do: true
@@ -171,7 +173,7 @@ defmodule Crontab.DateChecker do
     end
   end
 
-  @spec get_interval_value(interval :: CronExpression.interval(), date :: date) :: [
+  @spec get_interval_value(interval :: CronExpression.interval(), date :: DateHelper.date()) :: [
           CronExpression.time_unit()
         ]
   defp get_interval_value(:second, %{second: second}), do: [second]

--- a/lib/crontab/date_helper.ex
+++ b/lib/crontab/date_helper.ex
@@ -303,15 +303,13 @@ defmodule Crontab.DateHelper do
     adjustment = datetime.std_offset - candidate.std_offset
     adjusted = DateTime.add(candidate, adjustment, :second)
 
-    case adjusted.std_offset == candidate.std_offset do
-      false ->
+    if adjusted.std_offset != candidate.std_offset do
         candidate
-
-      _ ->
-        case DateTime.from_naive(DateTime.to_naive(adjusted), adjusted.time_zone) do
-          {:ambiguous, _, target} -> target
-          {:ok, target} -> target
-        end
+    else
+      case DateTime.from_naive(DateTime.to_naive(adjusted), adjusted.time_zone) do
+        {:ambiguous, _, target} -> target
+        {:ok, target} -> target
+      end
     end
   end
 end

--- a/lib/crontab/date_helper.ex
+++ b/lib/crontab/date_helper.ex
@@ -3,10 +3,12 @@ defmodule Crontab.DateHelper do
 
   @type unit :: :year | :month | :day | :hour | :minute | :second | :microsecond
 
+  @type date :: NaiveDateTime.t() | DateTime.t()
+
   @units [
     {:year, {nil, nil}},
     {:month, {1, 12}},
-    {:day, {1, :end_onf_month}},
+    {:day, {1, :end_of_month}},
     {:hour, {0, 23}},
     {:minute, {0, 59}},
     {:second, {0, 59}},
@@ -21,8 +23,11 @@ defmodule Crontab.DateHelper do
       iex> Crontab.DateHelper.beginning_of(~N[2016-03-14 01:45:45.123], :year)
       ~N[2016-01-01 00:00:00]
 
+      iex> Crontab.DateHelper.beginning_of(~U[2016-03-14 01:45:45.123Z], :year)
+      ~U[2016-01-01 00:00:00Z]
+
   """
-  @spec beginning_of(NaiveDateTime.t(), unit) :: NaiveDateTime.t()
+  @spec beginning_of(date, unit :: unit) :: date when date: date
   def beginning_of(date, unit) do
     _beginning_of(date, proceeding_units(unit))
   end
@@ -35,16 +40,28 @@ defmodule Crontab.DateHelper do
       iex> Crontab.DateHelper.end_of(~N[2016-03-14 01:45:45.123], :year)
       ~N[2016-12-31 23:59:59.999999]
 
+      iex> Crontab.DateHelper.end_of(~U[2016-03-14 01:45:45.123Z], :year)
+      ~U[2016-12-31 23:59:59.999999Z]
+
   """
-  @spec end_of(NaiveDateTime.t(), unit) :: NaiveDateTime.t()
+  @spec end_of(date, unit :: unit) :: date when date: date
   def end_of(date, unit) do
     _end_of(date, proceeding_units(unit))
   end
 
   @doc """
-  Find the last occurrence of weekday in month.
+  Find last occurrence of weekday in month
+
+  ### Examples:
+
+      iex> Crontab.DateHelper.last_weekday(~N[2016-03-14 01:45:45.123], 6)
+      26
+
+      iex> Crontab.DateHelper.last_weekday(~U[2016-03-14 01:45:45.123Z], 6)
+      26
+
   """
-  @spec last_weekday(NaiveDateTime.t(), Calendar.day_of_week()) :: Calendar.day()
+  @spec last_weekday(date :: date, day_of_week :: Calendar.day_of_week()) :: Calendar.day()
   def last_weekday(date, weekday) do
     date
     |> end_of(:month)
@@ -52,9 +69,19 @@ defmodule Crontab.DateHelper do
   end
 
   @doc """
-  Find the nth weekday of month.
+  Find nth weekday of month
+
+  ### Examples:
+
+      iex> Crontab.DateHelper.nth_weekday(~N[2016-03-14 01:45:45.123], 6, 2)
+      12
+
+      iex> Crontab.DateHelper.nth_weekday(~U[2016-03-14 01:45:45.123Z], 6, 2)
+      12
+
   """
-  @spec nth_weekday(NaiveDateTime.t(), Calendar.day_of_week(), integer) :: Calendar.day()
+  @spec nth_weekday(date :: date, weekday :: Calendar.day_of_week(), n :: pos_integer) ::
+          Calendar.day()
   def nth_weekday(date, weekday, n) do
     date
     |> beginning_of(:month)
@@ -62,7 +89,16 @@ defmodule Crontab.DateHelper do
   end
 
   @doc """
-  Find the last occurrence of weekday in month.
+  Find last occurrence of weekday in month
+
+  ### Examples:
+
+      iex> Crontab.DateHelper.last_weekday_of_month(~N[2016-03-14 01:45:45.123])
+      31
+
+      iex> Crontab.DateHelper.last_weekday_of_month(~U[2016-03-14 01:45:45.123Z])
+      31
+
   """
   @spec last_weekday_of_month(NaiveDateTime.t()) :: Calendar.day()
   def last_weekday_of_month(date) do
@@ -70,9 +106,18 @@ defmodule Crontab.DateHelper do
   end
 
   @doc """
-  Find the next occurrence of weekday relative to date.
+  Find next occurrence of weekday relative to date
+
+  ### Examples:
+
+      iex> Crontab.DateHelper.next_weekday_to(~N[2016-03-14 01:45:45.123])
+      14
+
+      iex> Crontab.DateHelper.next_weekday_to(~U[2016-03-14 01:45:45.123Z])
+      14
+
   """
-  @spec next_weekday_to(NaiveDateTime.t()) :: Calendar.day()
+  @spec next_weekday_to(date :: date) :: Calendar.day()
   def next_weekday_to(date = %NaiveDateTime{year: year, month: month, day: day}) do
     weekday = :calendar.day_of_the_week(year, month, day)
     next_day = NaiveDateTime.add(date, 1, :day)
@@ -87,8 +132,36 @@ defmodule Crontab.DateHelper do
     end
   end
 
-  @spec inc_year(NaiveDateTime.t()) :: NaiveDateTime.t()
-  def inc_year(date) do
+  def next_weekday_to(date = %DateTime{year: year, month: month, day: day}) do
+    weekday = :calendar.day_of_the_week(year, month, day)
+    # FIXME: How to correct date with tz?
+    next_day = DateTime.add(date, 1, :day)
+    # FIXME: How to correct date with tz?
+    previous_day = DateTime.add(date, -1, :day)
+
+    cond do
+      weekday == 7 && next_day.month == date.month -> next_day.day
+      weekday == 7 -> DateTime.add(date, -2, :day).day
+      weekday == 6 && previous_day.month == date.month -> previous_day.day
+      weekday == 6 -> DateTime.add(date, 2, :day).day
+      true -> date.day
+    end
+  end
+
+  @doc """
+  Increment Year
+
+  ### Examples:
+
+      iex> Crontab.DateHelper.inc_year(~N[2016-03-14 01:45:45.123])
+      ~N[2017-03-15 01:45:45.123]
+
+      iex> Crontab.DateHelper.inc_year(~U[2016-03-14 01:45:45.123Z])
+      ~U[2017-03-15 01:45:45.123Z]
+
+  """
+  @spec inc_year(date) :: date when date: date
+  def inc_year(date = %NaiveDateTime{}) do
     leap_year? =
       date
       |> NaiveDateTime.to_date()
@@ -101,8 +174,35 @@ defmodule Crontab.DateHelper do
     end
   end
 
-  @spec dec_year(NaiveDateTime.t()) :: NaiveDateTime.t()
-  def dec_year(date) do
+  def inc_year(date = %DateTime{}) do
+    leap_year? =
+      date
+      |> DateTime.to_date()
+      |> Date.leap_year?()
+
+    if leap_year? do
+      # FIXME: How to correct date with tz?
+      DateTime.add(date, 366, :day)
+    else
+      # FIXME: How to correct date with tz?
+      DateTime.add(date, 365, :day)
+    end
+  end
+
+  @doc """
+  Decrement Year
+
+  ### Examples:
+
+      iex> Crontab.DateHelper.dec_year(~N[2016-03-14 01:45:45.123])
+      ~N[2015-03-14 01:45:45.123]
+
+      iex> Crontab.DateHelper.dec_year(~U[2016-03-14 01:45:45.123Z])
+      ~U[2015-03-14 01:45:45.123Z]
+
+  """
+  @spec dec_year(date) :: date when date: date
+  def dec_year(date = %NaiveDateTime{}) do
     leap_year? =
       date
       |> NaiveDateTime.to_date()
@@ -115,7 +215,34 @@ defmodule Crontab.DateHelper do
     end
   end
 
-  @spec inc_month(NaiveDateTime.t()) :: NaiveDateTime.t()
+  def dec_year(date = %DateTime{}) do
+    leap_year? =
+      date
+      |> DateTime.to_date()
+      |> Date.leap_year?()
+
+    if leap_year? do
+      # FIXME: How to correct date with tz?
+      DateTime.add(date, -366, :day)
+    else
+      # FIXME: How to correct date with tz?
+      DateTime.add(date, -365, :day)
+    end
+  end
+
+  @doc """
+  Increment Month
+
+  ### Examples:
+
+      iex> Crontab.DateHelper.inc_month(~N[2016-03-14 01:45:45.123])
+      ~N[2016-04-01 01:45:45.123]
+
+      iex> Crontab.DateHelper.inc_month(~U[2016-03-14 01:45:45.123Z])
+      ~U[2016-04-01 01:45:45.123Z]
+
+  """
+  @spec inc_month(date) :: date when date: date
   def inc_month(date = %NaiveDateTime{day: day}) do
     days =
       date
@@ -125,30 +252,84 @@ defmodule Crontab.DateHelper do
     NaiveDateTime.add(date, days + 1 - day, :day)
   end
 
-  @spec dec_month(NaiveDateTime.t()) :: NaiveDateTime.t()
-  def dec_month(date) do
+  def inc_month(date = %DateTime{day: day}) do
     days =
       date
-      |> NaiveDateTime.to_date()
+      |> DateTime.to_date()
       |> Date.days_in_month()
 
-    NaiveDateTime.add(date, -days, :day)
+    # FIXME: How to correct date with tz?
+    DateTime.add(date, days + 1 - day, :day)
   end
 
-  @spec _beginning_of(NaiveDateTime.t(), [{unit, {any, any}}]) :: NaiveDateTime.t()
+  @doc """
+  Decrement Month
+
+  ### Examples:
+
+      iex> Crontab.DateHelper.dec_month(~N[2016-03-14 01:45:45.123])
+      ~N[2016-02-14 01:45:45.123]
+
+      iex> Crontab.DateHelper.dec_month(~U[2016-03-14 01:45:45.123Z])
+      ~U[2016-02-14 01:45:45.123Z]
+
+      iex> Crontab.DateHelper.dec_month(~N[2011-05-31 23:59:59])
+      ~N[2011-04-30 23:59:59]
+
+  """
+  @spec dec_month(date) :: date when date: date
+  def dec_month(date = %NaiveDateTime{day: day}) do
+    days_in_last_month =
+      date
+      |> NaiveDateTime.to_date()
+      |> day_in_last_month
+      |> Date.days_in_month()
+
+    NaiveDateTime.add(date, -(day + max(days_in_last_month - day, 0)), :day)
+  end
+
+  def dec_month(date = %DateTime{day: day}) do
+    days_in_last_month =
+      date
+      |> DateTime.to_date()
+      |> day_in_last_month
+      |> Date.days_in_month()
+
+    # FIXME: How to correct date with tz?
+    DateTime.add(date, -(day + max(days_in_last_month - day, 0)), :day)
+  end
+
+  defp day_in_last_month(start_date), do: day_in_last_month(start_date, start_date)
+
+  defp day_in_last_month(date = %Date{month: month}, start_date = %Date{month: month}),
+    do: date |> Date.add(-1) |> day_in_last_month(start_date)
+
+  defp day_in_last_month(date, _start_date), do: date
+
+  @spec _beginning_of(date, [{unit, {any, any}}]) :: date when date: date
   defp _beginning_of(date, [{unit, {lower, _}} | tail]) do
     _beginning_of(Map.put(date, unit, lower), tail)
   end
 
   defp _beginning_of(date, []), do: date
 
-  @spec _end_of(NaiveDateTime.t(), [{unit, {any, any}}]) :: NaiveDateTime.t()
-  defp _end_of(date, [{unit, {_, :end_onf_month}} | tail]) do
+  @spec _end_of(date, [{unit, {any, any}}]) :: date when date: date
+  defp _end_of(date = %NaiveDateTime{}, [{unit, {_, :end_of_month}} | tail]) do
     upper =
       date
       |> NaiveDateTime.to_date()
       |> Date.days_in_month()
 
+    _end_of(Map.put(date, unit, upper), tail)
+  end
+
+  defp _end_of(date = %DateTime{}, [{unit, {_, :end_of_month}} | tail]) do
+    upper =
+      date
+      |> DateTime.to_date()
+      |> Date.days_in_month()
+
+    # FIXME: How to correct date with tz?
     _end_of(Map.put(date, unit, upper), tail)
   end
 
@@ -165,7 +346,7 @@ defmodule Crontab.DateHelper do
       |> Enum.reduce([], fn {key, value}, acc ->
         cond do
           Enum.count(acc) > 0 ->
-            Enum.concat(acc, [{key, value}])
+            [{key, value} | acc]
 
           key == unit ->
             [{key, value}]
@@ -174,13 +355,19 @@ defmodule Crontab.DateHelper do
             []
         end
       end)
+      |> Enum.reverse()
 
     units
   end
 
-  @spec nth_weekday(NaiveDateTime.t(), Calendar.day_of_week(), :start) :: boolean
+  @spec nth_weekday(date :: date, weekday :: Calendar.day_of_week(), position :: :start) ::
+          boolean
   defp nth_weekday(date = %NaiveDateTime{}, _, 0, :start),
     do: NaiveDateTime.add(date, -1, :day).day
+
+  # FIXME: How to correct date with tz?
+  defp nth_weekday(date = %DateTime{}, _, 0, :start),
+    do: DateTime.add(date, -1, :day).day
 
   defp nth_weekday(date = %NaiveDateTime{year: year, month: month, day: day}, weekday, n, :start) do
     if :calendar.day_of_the_week(year, month, day) == weekday do
@@ -190,7 +377,17 @@ defmodule Crontab.DateHelper do
     end
   end
 
-  @spec last_weekday_of_month(NaiveDateTime.t(), :end) :: Calendar.day()
+  defp nth_weekday(date = %DateTime{year: year, month: month, day: day}, weekday, n, :start) do
+    if :calendar.day_of_the_week(year, month, day) == weekday do
+      # FIXME: How to correct date with tz?
+      nth_weekday(DateTime.add(date, 1, :day), weekday, n - 1, :start)
+    else
+      # FIXME: How to correct date with tz?
+      nth_weekday(DateTime.add(date, 1, :day), weekday, n, :start)
+    end
+  end
+
+  @spec last_weekday_of_month(date :: date(), position :: :end) :: Calendar.day()
   defp last_weekday_of_month(date = %NaiveDateTime{year: year, month: month, day: day}, :end) do
     weekday = :calendar.day_of_the_week(year, month, day)
 
@@ -201,12 +398,33 @@ defmodule Crontab.DateHelper do
     end
   end
 
-  @spec last_weekday(NaiveDateTime.t(), non_neg_integer, :end) :: Calendar.day()
+  defp last_weekday_of_month(date = %DateTime{year: year, month: month, day: day}, :end) do
+    weekday = :calendar.day_of_the_week(year, month, day)
+
+    if weekday > 5 do
+      # FIXME: How to correct date with tz?
+      last_weekday_of_month(DateTime.add(date, -1, :day), :end)
+    else
+      day
+    end
+  end
+
+  @spec last_weekday(date :: date, weekday :: Calendar.day_of_week(), position :: :end) ::
+          Calendar.day()
   defp last_weekday(date = %NaiveDateTime{year: year, month: month, day: day}, weekday, :end) do
     if :calendar.day_of_the_week(year, month, day) == weekday do
       day
     else
       last_weekday(NaiveDateTime.add(date, -1, :day), weekday, :end)
+    end
+  end
+
+  defp last_weekday(date = %DateTime{year: year, month: month, day: day}, weekday, :end) do
+    if :calendar.day_of_the_week(year, month, day) == weekday do
+      day
+    else
+      # FIXME: How to correct date with tz?
+      last_weekday(DateTime.add(date, -1, :day), weekday, :end)
     end
   end
 end

--- a/lib/crontab/date_helper.ex
+++ b/lib/crontab/date_helper.ex
@@ -214,20 +214,12 @@ defmodule Crontab.DateHelper do
   """
   @spec dec_month(date) :: date when date: date
   def dec_month(date = %{year: year, month: month, day: day}) do
-    days_in_last_month =
-      Date.new!(year, month, day)
-      |> day_in_last_month
-      |> Date.days_in_month()
-
+    days_in_last_month = Date.new!(year, month, 1) |> Date.add(-1) |> Date.days_in_month()
     add(date, -(day + max(days_in_last_month - day, 0)), :day)
   end
 
-  defp day_in_last_month(start_date), do: day_in_last_month(start_date, start_date)
-
-  defp day_in_last_month(date = %Date{month: month}, start_date = %Date{month: month}),
-    do: date |> Date.add(-1) |> day_in_last_month(start_date)
-
-  defp day_in_last_month(date, _start_date), do: date
+  # defp day_in_last_month(%{year: year, month: month}),
+  # do: Date.new!(year, month, 1) |> Date.add(-1)
 
   @spec _beginning_of(date, [{unit, {any, any}}]) :: date when date: date
   defp _beginning_of(date, [{unit, {lower, _}} | tail]) do

--- a/lib/crontab/date_helper.ex
+++ b/lib/crontab/date_helper.ex
@@ -1,6 +1,4 @@
 defmodule Crontab.DateHelper do
-  use Private
-
   @moduledoc false
 
   @type unit :: :year | :month | :day | :hour | :minute | :second | :microsecond
@@ -297,24 +295,23 @@ defmodule Crontab.DateHelper do
     end
   end
 
-  private do
-    def add(datetime = %NaiveDateTime{}, amt, unit), do: NaiveDateTime.add(datetime, amt, unit)
+  @doc false
+  def add(datetime = %NaiveDateTime{}, amt, unit), do: NaiveDateTime.add(datetime, amt, unit)
 
-    def add(datetime = %DateTime{}, amt, unit) do
-      candidate = DateTime.add(datetime, amt, unit)
-      adjustment = datetime.std_offset - candidate.std_offset
-      adjusted = DateTime.add(candidate, adjustment, :second)
+  def add(datetime = %DateTime{}, amt, unit) do
+    candidate = DateTime.add(datetime, amt, unit)
+    adjustment = datetime.std_offset - candidate.std_offset
+    adjusted = DateTime.add(candidate, adjustment, :second)
 
-      case adjusted.std_offset == candidate.std_offset do
-        false ->
-          candidate
+    case adjusted.std_offset == candidate.std_offset do
+      false ->
+        candidate
 
-        _ ->
-          case DateTime.from_naive(DateTime.to_naive(adjusted), adjusted.time_zone) do
-            {:ambiguous, _, target} -> target
-            {:ok, target} -> target
-          end
-      end
+      _ ->
+        case DateTime.from_naive(DateTime.to_naive(adjusted), adjusted.time_zone) do
+          {:ambiguous, _, target} -> target
+          {:ok, target} -> target
+        end
     end
   end
 end

--- a/lib/crontab/date_helper.ex
+++ b/lib/crontab/date_helper.ex
@@ -309,21 +309,10 @@ defmodule Crontab.DateHelper do
         false ->
           candidate
 
-        true ->
-          adj_plus_1h = DateTime.add(adjusted, 1, :hour)
-
-          case adj_plus_1h.std_offset == adjusted.std_offset do
-            true ->
-              adjusted
-
-            _ ->
-              # the one hour at end of daylight savings with ambiguous timezone
-              # return datetime with the standard (not daylight savings) timezone
-              %DateTime{
-                adjusted
-                | std_offset: adj_plus_1h.std_offset,
-                  zone_abbr: adj_plus_1h.zone_abbr
-              }
+        _ ->
+          case DateTime.from_naive(DateTime.to_naive(adjusted), adjusted.time_zone) do
+            {:ambiguous, _, target} -> target
+            {:ok, target} -> target
           end
       end
     end

--- a/lib/crontab/date_helper.ex
+++ b/lib/crontab/date_helper.ex
@@ -100,10 +100,8 @@ defmodule Crontab.DateHelper do
       31
 
   """
-  @spec last_weekday_of_month(NaiveDateTime.t()) :: Calendar.day()
-  def last_weekday_of_month(date) do
-    last_weekday_of_month(end_of(date, :month), :end)
-  end
+  @spec last_weekday_of_month(date :: date()) :: Calendar.day()
+  def last_weekday_of_month(date), do: last_weekday_of_month(end_of(date, :month), :end)
 
   @doc """
   Find next occurrence of weekday relative to date
@@ -118,32 +116,16 @@ defmodule Crontab.DateHelper do
 
   """
   @spec next_weekday_to(date :: date) :: Calendar.day()
-  def next_weekday_to(date = %NaiveDateTime{year: year, month: month, day: day}) do
+  def next_weekday_to(date = %{year: year, month: month, day: day}) do
     weekday = :calendar.day_of_the_week(year, month, day)
-    next_day = NaiveDateTime.add(date, 1, :day)
-    previous_day = NaiveDateTime.add(date, -1, :day)
+    next_day = add(date, 1, :day)
+    previous_day = add(date, -1, :day)
 
     cond do
       weekday == 7 && next_day.month == date.month -> next_day.day
-      weekday == 7 -> NaiveDateTime.add(date, -2, :day).day
+      weekday == 7 -> add(date, -2, :day).day
       weekday == 6 && previous_day.month == date.month -> previous_day.day
-      weekday == 6 -> NaiveDateTime.add(date, 2, :day).day
-      true -> date.day
-    end
-  end
-
-  def next_weekday_to(date = %DateTime{year: year, month: month, day: day}) do
-    weekday = :calendar.day_of_the_week(year, month, day)
-    # FIXME: How to correct date with tz?
-    next_day = DateTime.add(date, 1, :day)
-    # FIXME: How to correct date with tz?
-    previous_day = DateTime.add(date, -1, :day)
-
-    cond do
-      weekday == 7 && next_day.month == date.month -> next_day.day
-      weekday == 7 -> DateTime.add(date, -2, :day).day
-      weekday == 6 && previous_day.month == date.month -> previous_day.day
-      weekday == 6 -> DateTime.add(date, 2, :day).day
+      weekday == 6 -> add(date, 2, :day).day
       true -> date.day
     end
   end
@@ -161,33 +143,7 @@ defmodule Crontab.DateHelper do
 
   """
   @spec inc_year(date) :: date when date: date
-  def inc_year(date = %NaiveDateTime{}) do
-    leap_year? =
-      date
-      |> NaiveDateTime.to_date()
-      |> Date.leap_year?()
-
-    if leap_year? do
-      NaiveDateTime.add(date, 366, :day)
-    else
-      NaiveDateTime.add(date, 365, :day)
-    end
-  end
-
-  def inc_year(date = %DateTime{}) do
-    leap_year? =
-      date
-      |> DateTime.to_date()
-      |> Date.leap_year?()
-
-    if leap_year? do
-      # FIXME: How to correct date with tz?
-      DateTime.add(date, 366, :day)
-    else
-      # FIXME: How to correct date with tz?
-      DateTime.add(date, 365, :day)
-    end
-  end
+  def inc_year(date), do: add(date, days_in_year(date), :day)
 
   @doc """
   Decrement Year
@@ -202,33 +158,7 @@ defmodule Crontab.DateHelper do
 
   """
   @spec dec_year(date) :: date when date: date
-  def dec_year(date = %NaiveDateTime{}) do
-    leap_year? =
-      date
-      |> NaiveDateTime.to_date()
-      |> Date.leap_year?()
-
-    if leap_year? do
-      NaiveDateTime.add(date, -366, :day)
-    else
-      NaiveDateTime.add(date, -365, :day)
-    end
-  end
-
-  def dec_year(date = %DateTime{}) do
-    leap_year? =
-      date
-      |> DateTime.to_date()
-      |> Date.leap_year?()
-
-    if leap_year? do
-      # FIXME: How to correct date with tz?
-      DateTime.add(date, -366, :day)
-    else
-      # FIXME: How to correct date with tz?
-      DateTime.add(date, -365, :day)
-    end
-  end
+  def dec_year(date), do: add(date, -days_in_year(date), :day)
 
   @doc """
   Increment Month
@@ -243,23 +173,12 @@ defmodule Crontab.DateHelper do
 
   """
   @spec inc_month(date) :: date when date: date
-  def inc_month(date = %NaiveDateTime{day: day}) do
+  def inc_month(date = %{year: year, month: month, day: day}) do
     days =
-      date
-      |> NaiveDateTime.to_date()
+      Date.new!(year, month, day)
       |> Date.days_in_month()
 
-    NaiveDateTime.add(date, days + 1 - day, :day)
-  end
-
-  def inc_month(date = %DateTime{day: day}) do
-    days =
-      date
-      |> DateTime.to_date()
-      |> Date.days_in_month()
-
-    # FIXME: How to correct date with tz?
-    DateTime.add(date, days + 1 - day, :day)
+    add(date, days + 1 - day, :day)
   end
 
   @doc """
@@ -278,25 +197,13 @@ defmodule Crontab.DateHelper do
 
   """
   @spec dec_month(date) :: date when date: date
-  def dec_month(date = %NaiveDateTime{day: day}) do
+  def dec_month(date = %{year: year, month: month, day: day}) do
     days_in_last_month =
-      date
-      |> NaiveDateTime.to_date()
+      Date.new!(year, month, day)
       |> day_in_last_month
       |> Date.days_in_month()
 
-    NaiveDateTime.add(date, -(day + max(days_in_last_month - day, 0)), :day)
-  end
-
-  def dec_month(date = %DateTime{day: day}) do
-    days_in_last_month =
-      date
-      |> DateTime.to_date()
-      |> day_in_last_month
-      |> Date.days_in_month()
-
-    # FIXME: How to correct date with tz?
-    DateTime.add(date, -(day + max(days_in_last_month - day, 0)), :day)
+    add(date, -(day + max(days_in_last_month - day, 0)), :day)
   end
 
   defp day_in_last_month(start_date), do: day_in_last_month(start_date, start_date)
@@ -314,22 +221,11 @@ defmodule Crontab.DateHelper do
   defp _beginning_of(date, []), do: date
 
   @spec _end_of(date, [{unit, {any, any}}]) :: date when date: date
-  defp _end_of(date = %NaiveDateTime{}, [{unit, {_, :end_of_month}} | tail]) do
+  defp _end_of(date = %{year: year, month: month, day: day}, [{unit, {_, :end_of_month}} | tail]) do
     upper =
-      date
-      |> NaiveDateTime.to_date()
+      Date.new!(year, month, day)
       |> Date.days_in_month()
 
-    _end_of(Map.put(date, unit, upper), tail)
-  end
-
-  defp _end_of(date = %DateTime{}, [{unit, {_, :end_of_month}} | tail]) do
-    upper =
-      date
-      |> DateTime.to_date()
-      |> Date.days_in_month()
-
-    # FIXME: How to correct date with tz?
     _end_of(Map.put(date, unit, upper), tail)
   end
 
@@ -362,48 +258,19 @@ defmodule Crontab.DateHelper do
 
   @spec nth_weekday(date :: date, weekday :: Calendar.day_of_week(), position :: :start) ::
           boolean
-  defp nth_weekday(date = %NaiveDateTime{}, _, 0, :start),
-    do: NaiveDateTime.add(date, -1, :day).day
+  defp nth_weekday(date, _, 0, :start), do: add(date, -1, :day).day
 
-  # FIXME: How to correct date with tz?
-  defp nth_weekday(date = %DateTime{}, _, 0, :start),
-    do: DateTime.add(date, -1, :day).day
-
-  defp nth_weekday(date = %NaiveDateTime{year: year, month: month, day: day}, weekday, n, :start) do
-    if :calendar.day_of_the_week(year, month, day) == weekday do
-      nth_weekday(NaiveDateTime.add(date, 1, :day), weekday, n - 1, :start)
-    else
-      nth_weekday(NaiveDateTime.add(date, 1, :day), weekday, n, :start)
-    end
-  end
-
-  defp nth_weekday(date = %DateTime{year: year, month: month, day: day}, weekday, n, :start) do
-    if :calendar.day_of_the_week(year, month, day) == weekday do
-      # FIXME: How to correct date with tz?
-      nth_weekday(DateTime.add(date, 1, :day), weekday, n - 1, :start)
-    else
-      # FIXME: How to correct date with tz?
-      nth_weekday(DateTime.add(date, 1, :day), weekday, n, :start)
-    end
+  defp nth_weekday(date = %{year: year, month: month, day: day}, weekday, n, :start) do
+    modifier = if :calendar.day_of_the_week(year, month, day) == weekday, do: n - 1, else: n
+    nth_weekday(add(date, 1, :day), weekday, modifier, :start)
   end
 
   @spec last_weekday_of_month(date :: date(), position :: :end) :: Calendar.day()
-  defp last_weekday_of_month(date = %NaiveDateTime{year: year, month: month, day: day}, :end) do
+  defp last_weekday_of_month(date = %{year: year, month: month, day: day}, :end) do
     weekday = :calendar.day_of_the_week(year, month, day)
 
     if weekday > 5 do
-      last_weekday_of_month(NaiveDateTime.add(date, -1, :day), :end)
-    else
-      day
-    end
-  end
-
-  defp last_weekday_of_month(date = %DateTime{year: year, month: month, day: day}, :end) do
-    weekday = :calendar.day_of_the_week(year, month, day)
-
-    if weekday > 5 do
-      # FIXME: How to correct date with tz?
-      last_weekday_of_month(DateTime.add(date, -1, :day), :end)
+      last_weekday_of_month(add(date, -1, :day), :end)
     else
       day
     end
@@ -411,20 +278,23 @@ defmodule Crontab.DateHelper do
 
   @spec last_weekday(date :: date, weekday :: Calendar.day_of_week(), position :: :end) ::
           Calendar.day()
-  defp last_weekday(date = %NaiveDateTime{year: year, month: month, day: day}, weekday, :end) do
+  defp last_weekday(date = %{year: year, month: month, day: day}, weekday, :end) do
     if :calendar.day_of_the_week(year, month, day) == weekday do
       day
     else
-      last_weekday(NaiveDateTime.add(date, -1, :day), weekday, :end)
+      last_weekday(add(date, -1, :day), weekday, :end)
     end
   end
 
-  defp last_weekday(date = %DateTime{year: year, month: month, day: day}, weekday, :end) do
-    if :calendar.day_of_the_week(year, month, day) == weekday do
-      day
-    else
-      # FIXME: How to correct date with tz?
-      last_weekday(DateTime.add(date, -1, :day), weekday, :end)
+  defp add(datetime = %DateTime{}, amt, unit), do: DateTime.add(datetime, amt, unit)
+  defp add(datetime = %NaiveDateTime{}, amt, unit), do: NaiveDateTime.add(datetime, amt, unit)
+
+  defp days_in_year(%{year: year}) do
+    Date.new!(year, 1, 1)
+    |> Date.leap_year?()
+    |> case do
+      true -> 366
+      false -> 365
     end
   end
 end

--- a/lib/crontab/date_helper.ex
+++ b/lib/crontab/date_helper.ex
@@ -116,8 +116,8 @@ defmodule Crontab.DateHelper do
 
   """
   @spec next_weekday_to(date :: date) :: Calendar.day()
-  def next_weekday_to(date = %{year: year, month: month, day: day}) do
-    weekday = :calendar.day_of_the_week(year, month, day)
+  def next_weekday_to(date) do
+    weekday = Date.day_of_week(date)
     next_day = add(date, 1, :day)
     previous_day = add(date, -1, :day)
 
@@ -276,16 +276,14 @@ defmodule Crontab.DateHelper do
           boolean
   defp nth_weekday(date, _, 0, :start), do: add(date, -1, :day).day
 
-  defp nth_weekday(date = %{year: year, month: month, day: day}, weekday, n, :start) do
-    modifier = if :calendar.day_of_the_week(year, month, day) == weekday, do: n - 1, else: n
+  defp nth_weekday(date, weekday, n, :start) do
+    modifier = if Date.day_of_week(date) == weekday, do: n - 1, else: n
     nth_weekday(add(date, 1, :day), weekday, modifier, :start)
   end
 
   @spec last_weekday_of_month(date :: date(), position :: :end) :: Calendar.day()
-  defp last_weekday_of_month(date = %{year: year, month: month, day: day}, :end) do
-    weekday = :calendar.day_of_the_week(year, month, day)
-
-    if weekday > 5 do
+  defp last_weekday_of_month(date = %{day: day}, :end) do
+    if Date.day_of_week(date) > 5 do
       last_weekday_of_month(add(date, -1, :day), :end)
     else
       day
@@ -294,8 +292,8 @@ defmodule Crontab.DateHelper do
 
   @spec last_weekday(date :: date, weekday :: Calendar.day_of_week(), position :: :end) ::
           Calendar.day()
-  defp last_weekday(date = %{year: year, month: month, day: day}, weekday, :end) do
-    if :calendar.day_of_the_week(year, month, day) == weekday do
+  defp last_weekday(date = %{day: day}, weekday, :end) do
+    if Date.day_of_week(date) == weekday do
       day
     else
       last_weekday(add(date, -1, :day), weekday, :end)

--- a/lib/crontab/date_helper.ex
+++ b/lib/crontab/date_helper.ex
@@ -218,9 +218,6 @@ defmodule Crontab.DateHelper do
     add(date, -(day + max(days_in_last_month - day, 0)), :day)
   end
 
-  # defp day_in_last_month(%{year: year, month: month}),
-  # do: Date.new!(year, month, 1) |> Date.add(-1)
-
   @spec _beginning_of(date, [{unit, {any, any}}]) :: date when date: date
   defp _beginning_of(date, [{unit, {lower, _}} | tail]) do
     _beginning_of(Map.put(date, unit, lower), tail)
@@ -229,11 +226,8 @@ defmodule Crontab.DateHelper do
   defp _beginning_of(date, []), do: date
 
   @spec _end_of(date, [{unit, {any, any}}]) :: date when date: date
-  defp _end_of(date = %{year: year, month: month, day: day}, [{unit, {_, :end_of_month}} | tail]) do
-    upper =
-      Date.new!(year, month, day)
-      |> Date.days_in_month()
-
+  defp _end_of(date, [{unit, {_, :end_of_month}} | tail]) do
+    upper = Date.days_in_month(date)
     _end_of(Map.put(date, unit, upper), tail)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,9 @@ defmodule Crontab.Mixfile do
       {:excoveralls, "~> 0.5", only: [:test], runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev], runtime: false},
       {:credo, "~> 1.0", only: [:dev], runtime: false},
-      {:mix_test_watch, "~> 1.1", only: [:dev, :test], runtime: false}
+      {:mix_test_watch, "~> 1.1", only: [:dev, :test], runtime: false},
+      {:private, "~> 0.1", only: [:dev, :test], runtime: false},
+      {:tz, "~> 0.26", only: [:dev, :test]}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,8 @@ defmodule Crontab.Mixfile do
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:excoveralls, "~> 0.5", only: [:test], runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev], runtime: false},
-      {:credo, "~> 1.0", only: [:dev], runtime: false}
+      {:credo, "~> 1.0", only: [:dev], runtime: false},
+      {:mix_test_watch, "~> 1.1", only: [:dev, :test], runtime: false}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,6 @@ defmodule Crontab.Mixfile do
       {:dialyxir, "~> 1.0", only: [:dev], runtime: false},
       {:credo, "~> 1.0", only: [:dev], runtime: false},
       {:mix_test_watch, "~> 1.1", only: [:dev, :test], runtime: false},
-      {:private, "~> 0.1", only: [:dev, :test], runtime: false},
       {:tz, "~> 0.26", only: [:dev, :test]}
     ]
   end

--- a/test/crontab/date_helper_test.exs
+++ b/test/crontab/date_helper_test.exs
@@ -4,10 +4,71 @@ defmodule Crontab.DateHelperTest do
   use ExUnit.Case, async: true
 
   doctest Crontab.DateHelper
+  alias Crontab.DateHelper
 
   describe "inc_month/1" do
     test "does not jump over month" do
-      assert Crontab.DateHelper.inc_month(~N[2019-05-31 23:00:00]) == ~N[2019-06-01 23:00:00]
+      assert DateHelper.inc_month(~N[2019-05-31 23:00:00]) == ~N[2019-06-01 23:00:00]
+    end
+  end
+
+  describe "add/3 on NaiveDateTime" do
+    test "one day to day before NY DST starts" do
+      date = ~N[2024-03-09 12:34:56]
+      assert DateHelper.add(date, 1, :day) == ~N[2024-03-10 12:34:56]
+    end
+  end
+
+  describe "add/3 on DateTime UTC" do
+    test "one day to day before NY DST starts" do
+      date = ~U[2024-03-09 12:34:56Z]
+      assert DateHelper.add(date, 1, :day) == ~U[2024-03-10 12:34:56Z]
+    end
+  end
+
+  describe "add/3 on DateTime NYT" do
+    test "one day to day before NY DST starts" do
+      day_before = DateTime.from_naive!(~N[2024-03-09 12:34:56], "America/New_York")
+      expected = DateTime.from_naive!(~N[2024-03-10 12:34:56], "America/New_York")
+
+      assert DateHelper.add(day_before, 1, :day) == expected
+    end
+
+    test "one day to day before NY DST ends" do
+      day_before = DateTime.from_naive!(~N[2024-11-02 12:34:56], "America/New_York")
+      expected = DateTime.from_naive!(~N[2024-11-03 12:34:56], "America/New_York")
+
+      assert DateHelper.add(day_before, 1, :day) == expected
+    end
+
+    for {unit, time} <- [{:second, ~T[03:00:00]}, {:minute, ~T[03:00:59]}, {:hour, ~T[03:59:59]}] do
+      test "one #{unit} to one second before NY DST starts" do
+        one_sec_before = DateTime.from_naive!(~N[2024-03-10 01:59:59], "America/New_York")
+        expected = DateTime.new!(~D[2024-03-10], unquote(Macro.escape(time)), "America/New_York")
+
+        assert DateHelper.add(one_sec_before, 1, unquote(unit)) == expected
+      end
+    end
+
+    # , {:minute, ~T[01:00:59]}, {:hour, ~T[01:59:59]}] do
+    for {unit, hour, minute, second} <- [{:second, 1, 0, 0}, {:minute, 1, 0, 59}, {:hour, 1, 59, 59}] do
+      test "one #{unit} to one second before NY DST ends" do
+        one_sec_before = DateTime.from_naive!(~N[2024-11-03 00:59:59], "America/New_York")
+
+        # 'cos 1:00:00 to 1:59:00 can be represented as timezones for EDT and EST,
+        # so "work backwards" by getting the EST time from 2:00 onwards then minus 1 hour
+        two_plus = Time.new!(unquote(hour) + 1, unquote(minute), unquote(second))
+
+        expected =
+          DateTime.new!(~D[2024-11-03], two_plus, "America/New_York")
+          |> DateTime.add(-1, :hour)
+
+        assert DateHelper.add(one_sec_before, 1, unquote(unit)) == expected
+      end
+    end
+
+    setup do
+      Calendar.put_time_zone_database(Tz.TimeZoneDatabase)
     end
   end
 end

--- a/test/crontab/date_helper_test.exs
+++ b/test/crontab/date_helper_test.exs
@@ -123,9 +123,5 @@ defmodule Crontab.DateHelperTest do
         assert DateHelper.add(one_sec_before, 1, unquote(unit)) == expected
       end
     end
-
-    setup do
-      Calendar.put_time_zone_database(Tz.TimeZoneDatabase)
-    end
   end
 end

--- a/test/crontab/date_helper_test.exs
+++ b/test/crontab/date_helper_test.exs
@@ -6,7 +6,7 @@ defmodule Crontab.DateHelperTest do
   doctest Crontab.DateHelper
 
   describe "inc_month/1" do
-    test "does not jump obver month" do
+    test "does not jump over month" do
       assert Crontab.DateHelper.inc_month(~N[2019-05-31 23:00:00]) == ~N[2019-06-01 23:00:00]
     end
   end

--- a/test/crontab/date_helper_test.exs
+++ b/test/crontab/date_helper_test.exs
@@ -50,7 +50,6 @@ defmodule Crontab.DateHelperTest do
       end
     end
 
-    # , {:minute, ~T[01:00:59]}, {:hour, ~T[01:59:59]}] do
     for {unit, hour, minute, second} <- [
           {:second, 1, 0, 0},
           {:minute, 1, 0, 59},

--- a/test/crontab/date_helper_test.exs
+++ b/test/crontab/date_helper_test.exs
@@ -51,7 +51,11 @@ defmodule Crontab.DateHelperTest do
     end
 
     # , {:minute, ~T[01:00:59]}, {:hour, ~T[01:59:59]}] do
-    for {unit, hour, minute, second} <- [{:second, 1, 0, 0}, {:minute, 1, 0, 59}, {:hour, 1, 59, 59}] do
+    for {unit, hour, minute, second} <- [
+          {:second, 1, 0, 0},
+          {:minute, 1, 0, 59},
+          {:hour, 1, 59, 59}
+        ] do
       test "one #{unit} to one second before NY DST ends" do
         one_sec_before = DateTime.from_naive!(~N[2024-11-03 00:59:59], "America/New_York")
 

--- a/test/crontab/date_helper_test.exs
+++ b/test/crontab/date_helper_test.exs
@@ -12,6 +12,60 @@ defmodule Crontab.DateHelperTest do
     end
   end
 
+  describe "dec_year/1" do
+    test "non-leap year back to leap year at end feb" do
+      given = ~N[2025-02-28 00:00:00]
+      assert DateHelper.dec_year(given) == ~N[2024-02-28 00:00:00]
+    end
+
+    test "leap year back to non-leap year at end feb" do
+      given = ~N[2024-02-29 00:00:00]
+      assert DateHelper.dec_year(given) == ~N[2023-02-28 00:00:00]
+    end
+
+    test "non-leap year back to leap year at start mar" do
+      given = ~N[2025-03-01 00:00:00]
+      assert DateHelper.dec_year(given) == ~N[2024-03-01 00:00:00]
+    end
+
+    test "leap year back to non-leap year at start mar" do
+      given = ~N[2024-03-01 00:00:00]
+      assert DateHelper.dec_year(given) == ~N[2023-03-01 00:00:00]
+    end
+
+    test "non-leap year back to non-leap year" do
+      given = ~N[2026-03-01 00:00:00]
+      assert DateHelper.dec_year(given) == ~N[2025-03-01 00:00:00]
+    end
+  end
+
+  describe "inc_year/1" do
+    test "non-leap year to leap year at end feb" do
+      given = ~N[2023-02-28 00:00:00]
+      assert DateHelper.inc_year(given) == ~N[2024-02-28 00:00:00]
+    end
+
+    test "leap year to non-leap year at end feb" do
+      given = ~N[2024-02-29 00:00:00]
+      assert DateHelper.inc_year(given) == ~N[2025-02-28 00:00:00]
+    end
+
+    test "non-leap year to leap year at start mar" do
+      given = ~N[2023-03-01 00:00:00]
+      assert DateHelper.inc_year(given) == ~N[2024-03-01 00:00:00]
+    end
+
+    test "leap year to non-leap year at start mar" do
+      given = ~N[2024-03-01 00:00:00]
+      assert DateHelper.inc_year(given) == ~N[2025-03-01 00:00:00]
+    end
+
+    test "non-leap year to non-leap year" do
+      given = ~N[2025-03-01 00:00:00]
+      assert DateHelper.inc_year(given) == ~N[2026-03-01 00:00:00]
+    end
+  end
+
   describe "add/3 on NaiveDateTime" do
     test "one day to day before NY DST starts" do
       date = ~N[2024-03-09 12:34:56]


### PR DESCRIPTION
@maennchen I've simplified `date_helper` with an extracted `add/3` function. As focus switches to testing that new function rigorously, I have to make it public during tests, I used PragDave's [private](https://hexdocs.pm/private/Private.html) library to keep `add/3` private in non-test environments,

Functions in `date_helper` are now all able to do datetime arithmetic correctly, even for time gaps when daylight savings starts, and ambiguous times when daylight savings ends.

One thing to note is that for ambiguous times when daylight saving ends, I've chosen to return the time with the standard timezone, e.g., between Eastern Daylight Time (EDT) and Eastern Standard Time (EST), `add/3` returns the time with EST. If you think it should return EDT instead, let me know, and I'll change it to that.

Resolves #69 