### PR TITLE
BUG in nth occurrence of weekday in a month when n=5

### DIFF
--- a/lib/crontab/date_helper.ex
+++ b/lib/crontab/date_helper.ex
@@ -81,12 +81,9 @@ defmodule Crontab.DateHelper do
 
   """
   @spec nth_weekday(date :: date, weekday :: Calendar.day_of_week(), n :: pos_integer) ::
-          Calendar.day()
-  def nth_weekday(date, weekday, n) do
-    date
-    |> beginning_of(:month)
-    |> nth_weekday(weekday, n, :start)
-  end
+          Calendar.day() | nil
+  def nth_weekday(%{month: month} = date, weekday, n),
+    do: find_nth_weekday(%{date | day: 1}, month, weekday, n)
 
   @doc """
   Find last occurrence of weekday in month
@@ -258,21 +255,24 @@ defmodule Crontab.DateHelper do
     units
   end
 
-  @spec nth_weekday(date :: date, weekday :: Calendar.day_of_week(), position :: :start) ::
-          boolean
-  defp nth_weekday(date, _, 0, :start), do: add(date, -1, :day).day
-
-  defp nth_weekday(date, weekday, n, :start) do
+  @spec find_nth_weekday(
+          date :: date,
+          month :: Calendar.month(),
+          weekday :: Calendar.day_of_week(),
+          n :: non_neg_integer()
+        ) :: Calendar.day() | nil
+  defp find_nth_weekday(%{month: month} = date, month, weekday, n) do
     modifier =
       if Date.day_of_week(date) == weekday,
         do: n - 1,
         else: n
 
-    increment_day = add(date, 1, :day)
-
-    if increment_day.month == date.month,
-      do: nth_weekday(increment_day, weekday, modifier, :start)
+    if modifier == 0,
+      do: date.day,
+      else: find_nth_weekday(add(date, 1, :day), month, weekday, modifier)
   end
+
+  defp find_nth_weekday(_, _, _, _), do: nil
 
   @spec last_weekday_of_month(date :: date(), position :: :end) :: Calendar.day()
   defp last_weekday_of_month(date = %{day: day}, :end) do

--- a/lib/crontab/date_helper.ex
+++ b/lib/crontab/date_helper.ex
@@ -263,8 +263,15 @@ defmodule Crontab.DateHelper do
   defp nth_weekday(date, _, 0, :start), do: add(date, -1, :day).day
 
   defp nth_weekday(date, weekday, n, :start) do
-    modifier = if Date.day_of_week(date) == weekday, do: n - 1, else: n
-    nth_weekday(add(date, 1, :day), weekday, modifier, :start)
+    modifier =
+      if Date.day_of_week(date) == weekday,
+        do: n - 1,
+        else: n
+
+    increment_day = add(date, 1, :day)
+
+    if increment_day.month == date.month,
+      do: nth_weekday(increment_day, weekday, modifier, :start)
   end
 
   @spec last_weekday_of_month(date :: date(), position :: :end) :: Calendar.day()

--- a/test/crontab/date_helper_test.exs
+++ b/test/crontab/date_helper_test.exs
@@ -6,6 +6,11 @@ defmodule Crontab.DateHelperTest do
   doctest Crontab.DateHelper
   alias Crontab.DateHelper
 
+  describe "nth_weekday/3" do
+    refute DateHelper.nth_weekday(~N[2024-11-01 00:00:00], 1, 5)
+    assert DateHelper.nth_weekday(~N[2024-12-01 00:00:00], 1, 5) == 30
+  end
+
   describe "inc_month/1" do
     test "does not jump over month" do
       assert DateHelper.inc_month(~N[2019-05-31 23:00:00]) == ~N[2019-06-01 23:00:00]

--- a/test/crontab/date_helper_test.exs
+++ b/test/crontab/date_helper_test.exs
@@ -9,6 +9,7 @@ defmodule Crontab.DateHelperTest do
   describe "nth_weekday/3" do
     refute DateHelper.nth_weekday(~N[2024-11-01 00:00:00], 1, 5)
     assert DateHelper.nth_weekday(~N[2024-12-01 00:00:00], 1, 5) == 30
+    assert DateHelper.nth_weekday(~N[2024-09-01 00:00:00], 1, 5) == 30
   end
 
   describe "inc_month/1" do

--- a/test/crontab/scheduler_test.exs
+++ b/test/crontab/scheduler_test.exs
@@ -94,4 +94,11 @@ defmodule Crontab.SchedulerTest do
              ~N[2024-10-22 12:00:07]
            ) == {:ok, ~N[2024-12-30 09:00:00]}
   end
+
+  test "check for 5th occurrence of weekday backwards as well" do
+    assert get_previous_run_date(
+             %Crontab.CronExpression{minute: [0], hour: [9], weekday: [{:"#", 1, 5}]},
+             ~N[2024-10-22 12:00:07]
+           ) == {:ok, ~N[2024-09-30 09:00:00]}
+  end
 end

--- a/test/crontab/scheduler_test.exs
+++ b/test/crontab/scheduler_test.exs
@@ -80,4 +80,18 @@ defmodule Crontab.SchedulerTest do
              ~N[1234-05-06 07:08:09]
            ) == {:ok, ~N[9999-12-31 23:59:59]}
   end
+
+  test "check day occurrences in month" do
+    assert get_next_run_date(
+             %Crontab.CronExpression{minute: [0], hour: [9], weekday: [{:"#", 1, 1}]},
+             ~N[2024-10-22 12:00:07]
+           ) == {:ok, ~N[2024-11-04 09:00:00]}
+  end
+
+  test "check day occurrences in month for 5th time" do
+    assert get_next_run_date(
+             %Crontab.CronExpression{minute: [0], hour: [9], weekday: [{:"#", 1, 5}]},
+             ~N[2024-10-22 12:00:07]
+           ) == {:ok, ~N[2024-12-30 09:00:00]}
+  end
 end


### PR DESCRIPTION
This does not seem to be correct:
```ex
iex(1)> "0 9 * * mon#5" |> Crontab.CronExpression.Parser.parse!() |> Crontab.Scheduler.get_next_run_date()
{:ok, ~N[2024-11-02 09:00:00]}
```
as 2024-11-02 is neither a monday nor a fifth occurrence of it

The actual expected run_date is `2024-12-30 09:00:00`

Should I try to fix this bug?